### PR TITLE
Add Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## 概要

GitHub Actions ワークフローの自動依存関係更新を有効化します。

## 変更内容

`.github/dependabot.yml` を追加：
- **対象**: GitHub Actions のみ
- **更新頻度**: 月次
- **PR 制限**: 最大5件
- **自動ラベル**: `dependencies`, `github-actions`

## 理由

- GitHub Actions の最新バージョンを自動的に追跡
- セキュリティアップデートの迅速な適用
- 保守作業の自動化

## 影響

- テンプレートリポジトリ本体のみ影響
- 学生リポジトリには影響なし（setup.sh で削除済み）

## 関連

- Closes #1
- Related: latex-ecosystem #56 (Phase 3)