### PR TITLE
Update to 2025f image and latex-release-action v2.3.0

### DIFF
--- a/.github/workflows/latex-build.yml
+++ b/.github/workflows/latex-build.yml
@@ -19,12 +19,12 @@ jobs:
     name: Build LaTeX Poster and Create Release
     runs-on: ubuntu-latest
     # Use the latest TeXLive Japanese environment with textlint support
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2025f
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2025g
 
     steps:
       # Build LaTeX documents using the latex-release-action
       - name: Build and Release LaTeX Poster
-        uses: smkwlab/latex-release-action@v2.3.0
+        uses: smkwlab/latex-release-action@v2.5.0
         with:
           # Specify the poster file to build
           files: a0poster

--- a/.github/workflows/latex-build.yml
+++ b/.github/workflows/latex-build.yml
@@ -19,12 +19,12 @@ jobs:
     name: Build LaTeX Poster and Create Release
     runs-on: ubuntu-latest
     # Use the latest TeXLive Japanese environment with textlint support
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2025d
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2025f
 
     steps:
       # Build LaTeX documents using the latex-release-action
       - name: Build and Release LaTeX Poster
-        uses: smkwlab/latex-release-action@v2.2.0
+        uses: smkwlab/latex-release-action@v2.3.0
         with:
           # Specify the poster file to build
           files: a0poster


### PR DESCRIPTION
## Changes

Updates Docker image and latex-release-action to resolve permission errors in GitHub Actions containers.

### Docker Image Update
- Update from `ghcr.io/smkwlab/texlive-ja-textlint:2025e` to `2025f`
- 2025f includes sudo support for automatic permission fixes

### Action Update
- Update from `smkwlab/latex-release-action@v2.2.0` to `v2.3.0`
- v2.3.0 includes automatic permission detection and fixes

## Problem Solved

Resolves EACCES (permission denied) errors when running in GitHub Actions containers with non-root users. The 2025e image introduced `texuser` (UID 2000) which couldn't write to GitHub Actions temp directories owned by UID 1001.