### PR TITLE
Update setup.sh command to use positional argument syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@
 
 #### 下川研学生向け
 ```bash
-DOC_TYPE=poster /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)" bash poster
 ```
 
 #### それ以外の皆さん向け
 ```bash
-INDIVIDUAL_MODE=true DOC_TYPE=poster /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
+INDIVIDUAL_MODE=true /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)" bash poster
 ```
 
 **自動セットアップの特徴**:


### PR DESCRIPTION
## Summary

Update README.md to reflect the new positional argument syntax for setup.sh introduced in thesis-management-tools#351.

## Changes

- Update setup command from environment variable style to positional argument style
- Old: `DOC_TYPE=poster /bin/bash -c "$(curl -fsSL URL)"`
- New: `/bin/bash -c "$(curl -fsSL URL)" bash poster`
- Applied to both lab student and individual mode examples

## Related

- thesis-management-tools#350
- thesis-management-tools#351