### PR TITLE
Update latex-release-action from v2.5.0 to v3.0.4

### DIFF
--- a/.github/workflows/latex-build.yml
+++ b/.github/workflows/latex-build.yml
@@ -18,19 +18,16 @@ jobs:
   build-and-release-pdf:
     name: Build LaTeX Poster and Create Release
     runs-on: ubuntu-latest
-    # Use the latest TeXLive Japanese environment with textlint support
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2025g
 
     steps:
-      # Build LaTeX documents using the latex-release-action
+      - uses: actions/checkout@v4
       - name: Build and Release LaTeX Poster
-        uses: smkwlab/latex-release-action@v2.5.0
+        uses: smkwlab/latex-release-action@v3.0.4
+        env:
+          GH_TOKEN: ${{ github.token }}
         with:
           # Specify the poster file to build
           files: a0poster
-
-          # Upload PDFs as artifacts for pull requests (enables preview)
-          upload_on_pr: true
 
           # latexmk will use .latexmkrc configuration for lualatex
           # No additional options needed - respects lualatex workflow


### PR DESCRIPTION
## Summary

Updates \`latex-release-action\` from v2.5.0 (Composite Action) to v3.0.4 (Docker Container Action) to use the latest fixes including:
- Fixed GitHub token passing issue (v3.0.3)
- Fixed git safe.directory error (v3.0.4)

## Changes

- Remove \`container\` specification (now handled internally by Docker Container Action)
- Add \`actions/checkout@v4\` step (required in v3.x)
- Update to \`latex-release-action@v3.0.4\`
- Add \`GH_TOKEN\` environment variable (required in v3.x)
- Remove \`upload_on_pr\` option (handled automatically in v3.x)

## Migration Notes

This follows the standard migration path from v2.x to v3.x:
1. Container management moved from workflow to action
2. GitHub token must be explicitly passed via \`env.GH_TOKEN\`
3. Checkout step is now required
4. Pull request artifact upload is automatic (no option needed)

## Testing

CI will automatically test the workflow on this PR.