### PR TITLE
Add GitHub CLI prerequisites to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,27 @@
 
 ## 🔧 使用方法
 
+### 前提条件
+
+以下のソフトウェアがインストール済みであること：
+
+1. **Docker Desktop** - LaTeX 環境の実行に必要
+2. **GitHub Desktop** - リポジトリ管理・同期に必要
+3. **GitHub CLI (gh)** - リポジトリ作成スクリプトの実行に必要
+   - [インストール方法](https://github.com/smkwlab/thesis-management-tools/blob/main/docs/INSTALL-GH.md)
+
+### 準備
+
+GitHub CLI の認証を完了してください：
+
+```bash
+gh auth login
+```
+
+**注意:** `gh` コマンドが見つからない場合は [インストール方法](https://github.com/smkwlab/thesis-management-tools/blob/main/docs/INSTALL-GH.md) を参照してください。
+
 ### 自動セットアップ（推奨）
+
 [thesis-management-tools](https://github.com/smkwlab/thesis-management-tools)の自動セットアップスクリプトを使用：
 
 #### 下川研学生向け
@@ -28,22 +48,20 @@
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)" bash poster
 ```
 
+**実行手順:**
+1. 上記コマンドを実行（macOS のターミナルまたは Windows の WSL 内）
+2. 学籍番号・ポスター名を入力
+3. 自動でリポジトリ作成・セットアップ完了（リポジトリ名: `学籍番号-ポスター名`）
+
 #### それ以外の皆さん向け
 ```bash
 INDIVIDUAL_MODE=true /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)" bash poster
 ```
 
-**自動セットアップの特徴**:
-
-**下川研学生向け**:
-- 学籍番号・ポスター名の対話的入力
-- リポジトリ名: `学籍番号-ポスター名` (例: `smkwlab/k21rs001-jxiv2025-poster`)
-
-**それ以外の皆さん向け**:
-- リポジトリ名: `ポスター名` (例: `my-conference-poster`)
-
-**共通機能**:
-- リポジトリの自動作成とLaTeX環境の追加
+**実行手順:**
+1. 上記コマンドを実行（macOS のターミナルまたは Windows の WSL 内）
+2. ポスター名を入力
+3. 自動でリポジトリ作成・セットアップ完了（リポジトリ名: `ポスター名`）
 
 ### 手動セットアップ
 1. このテンプレートから新しいリポジトリを作成


### PR DESCRIPTION
## Summary

Part of smkwlab/thesis-management-tools#376

README に GitHub CLI の前提条件とシンプルなセットアップ手順を追加しました。

## Changes

- 前提条件セクションを追加（Docker Desktop, GitHub Desktop, GitHub CLI）
- 準備セクションを追加（`gh auth login`のみ）
- 共通ドキュメント ([INSTALL-GH.md](https://github.com/smkwlab/thesis-management-tools/blob/main/docs/INSTALL-GH.md)) へのリンクを追加
- 自動セットアップの実行手順を明確化

## Benefits

- GitHub CLI が必要であることを明示
- エラー駆動でインストール手順を参照
- setup.sh の実行が目立つ

## Related

- Main PR: smkwlab/thesis-management-tools#377