### PR TITLE
Set default font to Gothic for better poster readability

### DIFF
--- a/a0poster.tex
+++ b/a0poster.tex
@@ -1,15 +1,18 @@
 \documentclass[25pt, a0paper, portrait]{tikzposter}
 \usepackage{luatexja}
 \usepackage{luatexja-fontspec}
+\usepackage[table]{xcolor}
 
-\usetheme{Simple}
-%\usetheme{Minimal}
-%\usetheme{Basic}
+\renewcommand{\kanjifamilydefault}{\gtdefault}
 
-%\useblockstyle{Minimal}
-%\useblockstyle{Basic}
-\useblockstyle{Slide}
-%\useblockstyle{Default}
+\usetheme{Autumn}
+\useblockstyle{Minimal}
+\colorlet{titlebgcolor}{cyan!20}
+\colorlet{titlefgcolor}{black}
+\colorlet{blocktitlebgcolor}{cyan}
+\colorlet{blocktitlefgcolor}{black}
+\colorlet{blockbodybgcolor}{white}
+\colorlet{backgroundcolor}{white}
 
 \title{ポスタータイトル}
 \author{著者名}
@@ -21,25 +24,25 @@
 
 \begin{columns}
     \column{0.5} % 左カラム（幅50%）
-    
+
     \block{セクション1}{
         ここに内容を記述します。
     }
-    
+
     \block{セクション2}{
         さらに内容を追加できます。
     }
-    
+
     \column{0.5} % 右カラム（幅50%）
-    
+
     \block{セクション3}{
         右側のカラムの内容です。
     }
-    
+
     \block{セクション4}{
         追加の内容。
     }
-    
+
 \end{columns}
 
 \end{document}


### PR DESCRIPTION
## 概要

ポスターテンプレートのスタイルを改善しました。

## 変更内容

### スタイル設定
- テーマを `Simple` から `Autumn` に変更
- ブロックスタイルを `Slide` から `Minimal` に変更
- コメントアウトされていたテーマ・スタイルオプションを削除

### カラー設定
- タイトル背景色: `cyan!20`
- タイトル文字色: `black`
- ブロックタイトル背景色: `cyan`
- ブロックタイトル文字色: `black`
- ブロック本文背景色: `white`
- 全体背景色: `white`

### フォント設定
- デフォルトフォントをゴシック体に変更: `\renewcommand{\kanjifamilydefault}{\gtdefault}`

### その他
- `xcolor` パッケージに `table` オプションを追加
- 空白行の整理（末尾空白の削除）