### PR TITLE
Fix .latexmkrc to use pdf_mode=4 for lualatex

### DIFF
--- a/.latexmkrc
+++ b/.latexmkrc
@@ -1,2 +1,2 @@
-$latex = 'lualatex -halt-on-error -interaction=nonstopmode';
-$pdf_mode = 3;
+$lualatex = 'lualatex -synctex=1 -halt-on-error -file-line-error -interaction=nonstopmode';
+$pdf_mode = 4;


### PR DESCRIPTION
## 概要

poster-template は lualatex を使用しますが、`.latexmkrc` の設定が lualatex のビルド方式と整合していませんでした。

## 問題点

```perl
$latex = 'lualatex -halt-on-error -interaction=nonstopmode';
$pdf_mode = 3;
```

- `$pdf_mode = 3` は **dvipdfmx 経由（DVI→PDF）** の指定だが、lualatex は PDF を直接出力する
- lualatex を `$latex` 変数に割り当てている（lualatex 用は `$lualatex` 変数）
- latexmk はログから PDF 出力を検出して dvipdfmx をスキップする救済動作で「動いてはいた」が、その過程で余分な latex 再実行（forced rerun）が発生していた

## 変更内容

```perl
$lualatex = 'lualatex -synctex=1 -halt-on-error -file-line-error -interaction=nonstopmode';
$pdf_mode = 4;
```

- lualatex の正規変数 `$lualatex` + `$pdf_mode = 4` に修正
- `-synctex=1` を追加（VSCode LaTeX Workshop の PDF↔ソース相互ジャンプ用）
- `-file-line-error` を追加（エラー位置の特定を容易に）

## 動作確認

ローカルでクリーンビルドを実施:
- exit 0
- `a0poster.pdf` 生成
- `a0poster.synctex.gz` 生成
- forced rerun が解消

## 備考

エコシステム全体の `.latexmkrc` 統一の第一弾です。このリポジトリで形を固めてから、他テンプレート（uplatex 系での `upmendex` 統一・`-synctex=1`/`-halt-on-error` 付与）へ横展開します。`-interaction=nonstopmode` の CI 側との二重指定回避は共有ワークフロー `smkwlab/.github` の改修が必要なため、別途対応します。