### PR TITLE
Pin shared workflows to @v1 and use pull_request trigger

### DIFF
--- a/.github/workflows/latex-build.yml
+++ b/.github/workflows/latex-build.yml
@@ -2,13 +2,13 @@
 name: Build and Release PDF
 
 on:
-  pull_request_target:
+  pull_request:
   push:
     tags:
       - '*'
 
 jobs:
   build:
-    uses: smkwlab/.github/.github/workflows/latex-build.yml@main
+    uses: smkwlab/.github/.github/workflows/latex-build.yml@v1
     with:
       files: "a0poster"

--- a/.github/workflows/notify-ml-on-pr.yml
+++ b/.github/workflows/notify-ml-on-pr.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   notify:
-    uses: smkwlab/.github/.github/workflows/notify-ml-on-pr.yml@main
+    uses: smkwlab/.github/.github/workflows/notify-ml-on-pr.yml@v1
     secrets: inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Note: This template requires LuaLaTeX with Japanese font support (LuaTeX-ja).
 ## Key Architecture
 
 - **a0poster.tex**: The primary LaTeX source file using `tikzposter` document class
-- **GitHub Actions**: Automated build and release workflow using `ghcr.io/smkwlab/texlive-ja-textlint:2025d` Docker container via `smkwlab/latex-release-action@v2.2.0`
+- **GitHub Actions**: Automated build and release via the shared `smkwlab/.github` LaTeX build workflow (`latex-build.yml@v1`), which centrally pins the `texlive-ja-textlint` Docker image and `latex-release-action` version for the whole ecosystem
 - **Output**: Generates `a0poster.pdf` (which is gitignored)
 
 ## Release Workflow


### PR DESCRIPTION
resolve #20

他テンプレートとの不整合3点を修正しました。

## 1. 共有ワークフローを `@v1` に固定
`latex-build.yml` / `notify-ml-on-pr.yml` の `smkwlab/.github` 参照を `@main` → `@v1` に変更。開発中の共有ワークフロー変更が即時波及するのを防ぎ、他テンプレート（sotsuron-template 等）と統一。

## 2. `pull_request_target` → `pull_request`（セキュリティ）
`latex-build.yml` のトリガーを `pull_request_target:` から `pull_request:` に変更し、sotsuron-template と同形にしました。`pull_request_target` は PR 元コードに書き込み権限付きトークンが渡るため fork PR で危険ですが、本ワークフローは PR 時に PDF をビルドして artifact をアップロードするのみ（リリースは `push: tags` 側）で、書き込みトークンは不要なため `pull_request` で十分です。

## 3. CLAUDE.md の版数記載（drift の恒久解消）
`2025d` / `latex-release-action@v2.2.0` というハードコード記載は陳腐化していました。具体版数をハードコードすると再び古くなるため、**共有 `smkwlab/.github` ワークフロー（`latex-build.yml@v1`）が版数を一元管理する**旨の記述に書き換え、drift の再発自体を解消しました（版数の正は共有ワークフロー側）。

## 検証
- ✅ `@main` / `pull_request_target` の残存: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)